### PR TITLE
Implement config parsing for SimVPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ Minimal GUI VPN client built with Electron and WireGuard.
 1. Place `wg.exe` and `wintun.dll` next to the application files.
 2. Run `npm start` during development or build with `npm run dist`.
 3. Use the **📄 Импорт** button to select a `.conf` file. The file is copied to `temp/imported.conf`.
-4. Press **🟢 GO VPN** to enable the `SimVPN` interface.
-5. Press **🔴 STOP VPN** to disable the interface.
+4. Press **🟢 GO VPN** to enable the `SimVPN` interface. The imported config is
+   cleaned so that only the `PrivateKey` and `[Peer]` sections are passed to
+   `wg.exe`. Address and DNS values are applied via `netsh`.
+5. Press **🔴 STOP VPN** to delete the interface.


### PR DESCRIPTION
## Summary
- parse imported WireGuard config to extract Address/DNS
- write cleaned config with only PrivateKey and [Peer] sections
- set interface address/DNS using netsh and update stop logic
- document the new behaviour in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686eff0873d08325885c788b9d38238b