### PR TITLE
Improve wireguard-go startup handling

### DIFF
--- a/Core/Interfaces/IVpnService.cs
+++ b/Core/Interfaces/IVpnService.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace VpnClient.Core.Interfaces;
 
 public enum VpnState
@@ -11,6 +13,7 @@ public enum VpnState
 public interface IVpnService
 {
     VpnState State { get; }
+    event Action<string>? LogReceived;
     Task ConnectAsync(string config);
     Task DisconnectAsync();
 }

--- a/UI/ViewModels/MainWindowViewModel.cs
+++ b/UI/ViewModels/MainWindowViewModel.cs
@@ -42,6 +42,7 @@ PersistentKeepalive = 25
     {
         _vpnService = vpnService;
         _logger = logger;
+        _vpnService.LogReceived += msg => AppendLog(msg);
     }
 
     public string ConnectionStatus => _vpnService.State switch


### PR DESCRIPTION
## Summary
- broadcast VPN service log lines via `LogReceived` event
- wait for `wireguard-go` readiness before marking VPN as connected
- forward service log lines to the main window log

## Testing
- `dotnet build VpnClient.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb238288483259def9c92bc777da3