### PR TITLE
Use wg.exe setconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ The UI project `VpnClient.UI` is the startup project.
 
 - `wintun.dll` must be accessible by the application (place it next to the built executable or add it to `PATH`).
 - `wireguard-go.exe` is used to establish the VPN tunnel and should also reside alongside the executable.
+- `wg.exe` is required to apply configuration to the running interface and must be available on `PATH` or next to the executable.


### PR DESCRIPTION
## Summary
- configure WireGuard interface using `wg.exe setconf`
- watch for UAPI output when starting `wireguard-go`
- mention `wg.exe` in runtime requirements

## Testing
- `dotnet build VpnClient.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbc06ed588325b25dd706dcb28548